### PR TITLE
fix(ci): clean up GH Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   clean_code:
-    name: Lint and format code
+    name: Check linting and formatting of code
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on pull requests
@@ -22,16 +22,16 @@ jobs:
       - name: Install packages
         run: npm ci
 
-      - name: Format with Prettier
+      - name: Check code formatting with Prettier
         run: npm run format
 
-      - name: Lint with eslint
+      - name: Check linting with ESLint
         run: npm run lint
 
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on pull requests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,11 @@
-name: Build Docker image and Publish to Registries
-
-env:
-  DOCKER_HUB_REPO: jacobtheeldest/minesweeper
+name: Build Docker Image and Publish to Registries
 
 on:
   release:
     types: [published]
 
 jobs:
-  build-and-push-image:
+  build-and-publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,8 +18,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
@@ -45,8 +40,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -59,7 +52,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and publish Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -68,4 +61,3 @@ jobs:
           cache-from: type=registry,ref=${{ env.DOCKER_HUB_REPO }}:buildcache
           cache-to: type=registry,ref=${{ env.DOCKER_HUB_REPO }}:buildcache,mode=max
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Clean up comments and rename jobs/steps of GitHub Actions workflows. Remove workflow-scope env variable DOCKER_HUB_REPO in favor of a repository-scope variable the repository's Actions secrets/variables.

closes #18