### PR TITLE
perf(docker): build app for production and dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.DS_Store
+.env
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM node:lts-alpine3.17
+FROM node:current-alpine as build
 
 WORKDIR /usr/src/app
-
 COPY package*.json ./
-
-RUN npm install
-
+RUN npm clean-install
 COPY . .
+RUN npm run build
 
-EXPOSE 3000
-
-CMD [ "npm", "run", "dev" ]
+FROM nginx:mainline-alpine
+EXPOSE 80
+COPY ./docker/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /usr/src/app/dist /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ services:
     image: jacobtheeldest/minesweeper:latest
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "80:80"
 
 ```

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Change Dockerfile to build app for production and server with nginx, rather than running the dev server. Create an nginx config to serve the app. Use .dockerignore to ensure nothing sensitive or wasteful is built into the image.  Update  .gitignore to prevent commit of build files. Update readme with appropriate nginx port.

closes #29